### PR TITLE
0.18.1 public pre-parsed face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.18.1
+* Make `PreParsedSubtables` `face` field public. This allows referencing and unwrapping the underlying face.
+
 # 0.18.0
 * Update _ttf-parser_ to `0.18.0`, [changelog](https://github.com/RazrFalcon/ttf-parser/blob/master/CHANGELOG.md#0180---2022-12-25).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 readme="README.md"
 
 [dependencies]
-ttf-parser = { version = "0.18", default-features = false }
+ttf-parser = { version = "0.18.1", default-features = false }
 
 [features] 
 default = ["std", "opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -34,6 +34,6 @@ impl FaceMut for ttf_parser::Face<'_> {
 impl FaceMut for &mut ttf_parser::Face<'_> {
     #[inline]
     fn set_variation(&mut self, axis: ttf_parser::Tag, value: f32) -> Option<()> {
-        ttf_parser::Face::set_variation(*self, axis, value)
+        ttf_parser::Face::set_variation(self, axis, value)
     }
 }

--- a/src/preparse.rs
+++ b/src/preparse.rs
@@ -28,7 +28,8 @@ use ttf_parser::{cmap, kern, Face, GlyphId};
 /// ```
 #[derive(Clone)]
 pub struct PreParsedSubtables<'face, F> {
-    pub(crate) face: F,
+    /// Underlying face.
+    pub face: F,
     // note must not be public as could be self-referencing
     pub(crate) subtables: FaceSubtables<'face>,
 }


### PR DESCRIPTION
Make `PreParsedSubtables` `face` field public. This allows referencing and unwrapping the underlying face.