### PR TITLE
Exclude test data and tools from published packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ repository = "https://github.com/alexheretic/owned-ttf-parser"
 keywords = ["ttf", "truetype", "otf", "opentype"]
 license = "Apache-2.0"
 readme = "README.md"
+include = [
+	"README.md",
+	"Cargo.toml",
+	"src/**/*.rs",
+        "LICENSE",
+]
 
 [dependencies]
 ttf-parser = { version = "0.25", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,8 @@ repository = "https://github.com/alexheretic/owned-ttf-parser"
 keywords = ["ttf", "truetype", "otf", "opentype"]
 license = "Apache-2.0"
 readme = "README.md"
-include = [
-	"README.md",
-	"Cargo.toml",
-	"src/**/*.rs",
-        "LICENSE",
-]
+# exclude fonts & tests to reduce published crate size
+include = ["README.md", "Cargo.toml", "src/**/*.rs", "LICENSE"]
 
 [dependencies]
 ttf-parser = { version = "0.25", default-features = false }


### PR DESCRIPTION
During our dependency reviews we discovered that the owned-ttf-parser crate as uploaded to crates.io includes test data and additional tools that are not used by the rust code. This increases the package size and makes it harder to review the source code.

This commit explicitly includes only relevant files. This helps to reduce the package size

Before: 20 files, 233.8KiB (148.0KiB compressed)
After: 10 files, 26.7KiB (8.8KiB compressed)

Overall based on the reduction in the compressed package size and the current download numbers that results to a traffic reduction for crates.io of around 170GB / Month.